### PR TITLE
Region Op Crashfix

### DIFF
--- a/app/src/main/kotlin/gg/destiny/lizard/chat/EmoteSpan.kt
+++ b/app/src/main/kotlin/gg/destiny/lizard/chat/EmoteSpan.kt
@@ -122,7 +122,7 @@ class EmoteSpan(context: Context, val emote: Emote, val invalidateListener: (() 
       workBounds.set(drawable.bounds)
       workBounds.offset(x.toInt(), newY.toInt())
       clipBounds.union(workBounds)
-      canvas.clipRect(clipBounds, Region.Op.REPLACE)
+      canvas.clipRect(clipBounds, Region.Op.INTERSECT)
       canvas.translate(x + translateX, newY)
       canvas.rotate(rotation)
       if (hueShift == 0f) {


### PR DESCRIPTION
- Changed the deprecated Region.Op.REPLACE -> Region.Op.INTERSECT
- Works on my machine.

Not sure if Intersect is the right choice, options are either Intersect or Difference.